### PR TITLE
add functionality for showing the location of a single attraction in …

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -66,4 +66,31 @@
     </script>
     <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['google_map_api_key'] %>&callback=initMap"
     async defer></script>
+
+  <% elsif @attraction %>
+
+    <div class="main-map col-xs-12 col-sm-12 col-md-9 col-lg-9" id="map"></div>
+    <script type='text/javascript' charset="utf-8">
+
+      var map;
+      var infowindow;
+
+      function initMap() {
+        var myLatLng = {lat: <%= @attraction.lat %>, lng: <%= @attraction.lng %>};
+
+        var map = new google.maps.Map(document.getElementById('map'), {
+          zoom: 16,
+          center: myLatLng
+        });
+
+        var marker = new google.maps.Marker({
+          position: myLatLng,
+          map: map,
+          title: 'Hello World!'
+        });
+      }
+    </script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['google_map_api_key'] %>&callback=initMap"
+    async defer></script>
 <% end %>
+


### PR DESCRIPTION
#### What does  this PR do?
Add the map view for a single attraction

#### Where should the reviewer start?
The logic is in views/search/index.html.erb

#### How should this be manually tested?
Run `rails s`
Go to localhost:3000 in your browser
On the root, click on a city, then click on an attraction and you should be redirected to the attraction details and see the map centered in that attraction coordinates

#### Any background context you want to provide?

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/148718343

#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? no
  - Do Environment Variables need to be set? no
  - Any other deploy steps? no