### PR TITLE
Vendor dashboard

### DIFF
--- a/app/views/vendor/dashboard/index.html.erb
+++ b/app/views/vendor/dashboard/index.html.erb
@@ -1,3 +1,3 @@
 Welcome <%= @vendor.first_name %>!
 <%= link_to "New Tour", new_user_vendor_tour_path(@vendor) %>
-New Trip
+<%= link_to "View All Tours", user_vendor_tours_path(@vendor) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     resources :trips, only: [:new, :index, :create, :show]
     namespace :vendor do
       get '/dashboard', to: 'dashboard#index'
-      resources :tours, only: [:new, :show]
+      resources :tours, only: [:new, :show, :index]
       post '/tours/:id', to: 'tours#create'
     end
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -19,5 +19,15 @@ FactoryGirl.define do
         create_list(:trip, evaluator.trips_count, user: user)
       end
     end
+
+    factory :user_with_tours do
+      transient do
+        tours_count 6
+      end
+
+      after(:create) do |user, evaluator|
+        create_list(:tour, evaluator.tours_count, user: user)
+      end
+    end
   end
 end

--- a/spec/features/vendor/vendor_accesses_tours_from_dashboard_spec.rb
+++ b/spec/features/vendor/vendor_accesses_tours_from_dashboard_spec.rb
@@ -1,0 +1,8 @@
+# click_on "View All Tours"
+
+#     expect(page).to have_selector('.tour', count: @vendor.tours.count)
+#     expect(page).to have_content(tour1.name)
+#     expect(page).to have_content(tour1.price)
+#     expect(page).to have_content(tour1.avg_rating)
+#     expect(page).to have_content("Edit")
+#     expect(page).to have_content("Delete")

--- a/spec/features/vendor/vendor_dashboard_spec.rb
+++ b/spec/features/vendor/vendor_dashboard_spec.rb
@@ -1,42 +1,40 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe "Vendor" do
-#   before :each do
-#     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(vendor)
-#     vendor = create(:user_with_tours)
-#     role = create(:role, name: "vendor")
-#     vendor.roles << role
-#     tour1 = vendor.tours.first
-#     # tour1 = create(:tour_with_rating) #??
-#     # vendor.tours << tour1
-#   end
+RSpec.describe "Vendor" do
+  before :each do
+    vendor = create(:user_with_tours, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(vendor)
+    tour1 = vendor.tours.first
+    # tour1 = create(:tour_with_rating) #??
+    # vendor.tours << tour1
+  end
 
-#   it "sees their dashboard" do
-#     visit "/vendor/#{vendor.id}/dashboard"
+  it "sees their dashboard" do
+    visit "/vendor/#{vendor.id}/dashboard"
 
-#     expect(page).to have_selector('.tour', count: vendor.tours.count)
-#     expect(page).to have_content(tour1.name)
-#     expect(page).to have_content(tour1.price)
-#     expect(page).to have_content(tour1.avg_rating)
-#     expect(page).to have_content("Edit")
-#     expect(page).to have_content("Delete")
-#     expect(page).to have_content("New Tour")
-#   end
+    expect(page).to have_selector('.tour', count: vendor.tours.count)
+    expect(page).to have_content(tour1.name)
+    expect(page).to have_content(tour1.price)
+    expect(page).to have_content(tour1.avg_rating)
+    expect(page).to have_content("Edit")
+    expect(page).to have_content("Delete")
+    expect(page).to have_content("New Tour")
+  end
 
-#   it "can't see other vendor's dashboard" do
-#     vendor2 = create(:user)
-#     role = create(:role, name: "vendor")
-#     vendor2.roles << role
+  xit "can't see other vendor's dashboard" do
+    vendor2 = create(:user)
+    role = create(:role, name: "vendor")
+    vendor2.roles << role
 
-#     visit "/vendor/#{vendor2.id}/dashboard"
+    visit "/vendor/#{vendor2.id}/dashboard"
 
-#     expect(page).to have_content "The page you were looking for doesn't exist."
-#   end
-# end
+    expect(page).to have_content "The page you were looking for doesn't exist."
+  end
+end
 
-# # As a vendor
-# # When I visit vendor/dashboard
-# # I see all my tours
-# # I see an edit button for each tour
-# # I see a delete button for each tour
-# # I see a “new tour” button
+# As a vendor
+# When I visit vendor/dashboard
+# I see all my tours
+# I see an edit button for each tour
+# I see a delete button for each tour
+# I see a “new tour” button

--- a/spec/features/vendor/vendor_dashboard_spec.rb
+++ b/spec/features/vendor/vendor_dashboard_spec.rb
@@ -2,23 +2,18 @@ require 'rails_helper'
 
 RSpec.describe "Vendor" do
   before :each do
-    vendor = create(:user_with_tours, role: 1)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(vendor)
-    tour1 = vendor.tours.first
+    @vendor = create(:user_with_tours, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@vendor)
+    tour1 = @vendor.tours.first
     # tour1 = create(:tour_with_rating) #??
     # vendor.tours << tour1
   end
 
   it "sees their dashboard" do
-    visit "/vendor/#{vendor.id}/dashboard"
+    visit user_vendor_dashboard_path(@vendor)
 
-    expect(page).to have_selector('.tour', count: vendor.tours.count)
-    expect(page).to have_content(tour1.name)
-    expect(page).to have_content(tour1.price)
-    expect(page).to have_content(tour1.avg_rating)
-    expect(page).to have_content("Edit")
-    expect(page).to have_content("Delete")
     expect(page).to have_content("New Tour")
+    expect(page).to have_content("View All Tours")
   end
 
   xit "can't see other vendor's dashboard" do

--- a/spec/features/vendor/vendor_dashboard_spec.rb
+++ b/spec/features/vendor/vendor_dashboard_spec.rb
@@ -16,14 +16,13 @@ RSpec.describe "Vendor" do
     expect(page).to have_content("View All Tours")
   end
 
-  xit "can't see other vendor's dashboard" do
-    vendor2 = create(:user)
-    role = create(:role, name: "vendor")
-    vendor2.roles << role
+  it "can't see other vendor's dashboard" do
+    vendor2 = create(:user, first_name: "other", role: 1)
 
-    visit "/vendor/#{vendor2.id}/dashboard"
+    visit "/users/#{vendor2.id}/vendor/dashboard"
 
-    expect(page).to have_content "The page you were looking for doesn't exist."
+    expect(page).to have_content "Welcome #{@vendor.first_name}"
+    expect(page).to_not have_content "Welcome #{vendor2.first_name}"
   end
 end
 


### PR DESCRIPTION
#### What does  this PR do? Ensures that one vendor does not have access to another vendor's dashboard. This functionality was present in the last vendor pull request, but is tested in this one. Also moved tour index expectations out of dashboard expectations
#### Where should the reviewer start? vendor_dashboard_spec.rb
#### How should this be manually tested? vendor_dashboard_spec.rb
#### Any background context you want to provide? We were originally testing for a 404 message when a vendor tries to access another vendor's dashboard. Instead, all routes lead to their own dashboard.
#### What are the relevant tickets? #148720233
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? No
  - Do Environment Variables need to be set? No
  - Any other deploy steps? No -- but if you want to check this out in development, you'll want to create/seed two vendors.