### PR TITLE
get add attraction button to work

### DIFF
--- a/app/assets/javascripts/nav_dropdowns.js
+++ b/app/assets/javascripts/nav_dropdowns.js
@@ -1,5 +1,5 @@
 $(document).on('turbolinks:load', function() {
-  $("a.add-attraction-button").on("click", function(event) {
+  $("a.add-attraction-button-current-user-and-trip").on("click", function(event) {
     event.preventDefault();
     let newUrl = $(this).attr("href");
     let selectedDay = $("select#days").val();

--- a/app/views/search/_city.html.erb
+++ b/app/views/search/_city.html.erb
@@ -4,7 +4,7 @@
     <a class="attraction-preview-link" href="/search?attraction=<%=attraction.place_id%>"></a>
 
     <% if current_user && @trip %>
-      <%= link_to "/users/#{current_user.id}/trips/#{@trip.id}?place_id=#{attraction.place_id}&name=#{attraction.name}&lat=#{attraction.lat}&lng=#{attraction.lng}", :method=> :put, class: "add-attraction-button btn btn-xs btn-warning btn-expand" do %>
+      <%= link_to "/users/#{current_user.id}/trips/#{@trip.id}?place_id=#{attraction.place_id}&name=#{attraction.name}&lat=#{attraction.lat}&lng=#{attraction.lng}", :method=> :put, class: "add-attraction-button btn btn-xs btn-warning btn-expand add-attraction-button-current-user-and-trip" do %>
         <i class="glyphicon glyphicon-plus"></i>&nbsp&nbsp<strong>SCHEDULE</strong>
       <% end %>
     <% elsif current_user %>


### PR DESCRIPTION
added new class to add attraction button to allow users to have different experiences depending on their login and trip status.

now, if they are not logged in and click the button, they are taken to the login page.
if they are logged in but do not have a trip selected, they are taken to their trips page to select a trip or start a new trip.
if they are logged in and have a trip selected, they can choose a day to add the attraction to and get an alert that the item has been added.